### PR TITLE
Fix read-only star focus handling

### DIFF
--- a/src/Rating.tsx
+++ b/src/Rating.tsx
@@ -44,7 +44,7 @@ const Rating: React.FC<RatingProps> = ({ value = 0, onChange, readOnly }) => {
           key={star}
           role="radio"
           aria-checked={rating === star}
-          tabIndex={0}
+          tabIndex={readOnly ? -1 : 0}
           onClick={() => handleClick(star)}
           onKeyDown={(e) => handleKeyDown(e, star)}
           className={star <= rating ? "star selected" : "star"}


### PR DESCRIPTION
## Summary
- prevent focus on stars when rating component is read-only

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68529f7792e0833095eea647f9913055