### PR TITLE
Fix read-only star focus handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build"
   },
   "eslintConfig": {

--- a/src/Rating.stories.tsx
+++ b/src/Rating.stories.tsx
@@ -1,5 +1,5 @@
 import Rating from "./Rating";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
 
 const meta: Meta<typeof Rating> = {
   title: "Custom/Rating",

--- a/src/Rating.tsx
+++ b/src/Rating.tsx
@@ -44,7 +44,7 @@ const Rating: React.FC<RatingProps> = ({ value = 0, onChange, readOnly }) => {
           key={star}
           role="radio"
           aria-checked={rating === star}
-          tabIndex={0}
+          tabIndex={readOnly ? -1 : 0}
           onClick={() => handleClick(star)}
           onKeyDown={(e) => handleKeyDown(e, star)}
           className={star <= rating ? "star selected" : "star"}


### PR DESCRIPTION
## Summary
- prevent focus on stars when rating component is read-only
- adjust Storybook import to satisfy ESLint
- disable automatic browser opening for Storybook

## Testing
- `CI=true npm test --silent`
- `npm run storybook` *(starts server without opening browser)*

------
https://chatgpt.com/codex/tasks/task_e_68529f7792e0833095eea647f9913055